### PR TITLE
added reset() and readConfigRegister() functions

### DIFF
--- a/HDC1050.cpp
+++ b/HDC1050.cpp
@@ -76,6 +76,25 @@ void HDC1050::updateConfigRegister()
 	Wire.endTransmission();
 }
 
+void HDC1050::readConfigRegister()
+{
+	readRegister(REG_Config, 2);
+	configReg = buf[0];
+}
+
+void HDC1050::reset()
+{
+        // perform sensor soft reset
+        configReg |= 1 << BIT_RST;
+	updateConfigRegister();
+	// wait for sensor to restart (datasheet lists max time as 15ms)
+	delay(25);
+
+	// restore configuration register values
+	configReg &= ~(1 << BIT_RST);
+	updateConfigRegister();
+}
+
 void HDC1050::setTemperatureRes(byte res) 
 {
 	if (res > 1) res = T_RES_14;
@@ -102,9 +121,7 @@ void HDC1050::turnOnHeater(bool heaterOn)
 
 bool HDC1050::batteryOK()
 {
-	readRegister(REG_Config, 2);
-	configReg = buf[0];
-	
+	readConfigRegister();
 	return (configReg & (1 << BIT_BATTERY_OK)) == 0;
 }
 

--- a/HDC1050.h
+++ b/HDC1050.h
@@ -47,6 +47,8 @@ public:
 	bool batteryOK();
 	float getTemperatureHumidity(float &t, float &h);
 	void updateConfigRegister();
+	void readConfigRegister();
+	void reset();
 	void readRegister(byte regAddr, byte numOfBytes);
 
 	byte configReg; //higher 8 bits of the configuration register


### PR DESCRIPTION
I needed to issue soft reset on the sensor, and noticed that if one attempts to read sensor values immediately after reset getTemperatureHumidity() can hang sometimes hang indefinitely.

So, I ended up adding reset() function to safely soft reset the sensor (and preserving the current configuration).  This can be used to simplify setup() function since often just need single call to reset() in there if using the sensor with default settings....